### PR TITLE
example on setting properties for OpenAI vision-capable models

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -262,4 +262,12 @@ export const openAiModels = {
 		inputPrice: 0.0001,
 		outputPrice: 0.0001,
 	},
+	"gpt-4o-2024-08-06": {
+		maxTokens: 16384,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.0000025,
+		outputPrice: 0.00001,
+	},
+	
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
The current default behavior of uploading images is disabled for all OpenAI models. This change sets an example when using the OpenAI model with vision capability for vision-related tasks.

Also, note that there is an unexpected behavior when `shouldDisableImages` is True: one cannot copy-paste text to the input box. I am not able to identify the cause of this issue.